### PR TITLE
Add close method to the client

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,10 @@ export class Client {
     })
   }
 
+  close(): void {
+    this.socket.disconnect()
+  }
+
   subscribe(request: AbsintheRequest, callback: SubscriptionCallback): Promise<Event> {
     return new Promise((resolve, reject) => {
       const normalizedQuery = this.normalizeQuery(request.query);


### PR DESCRIPTION
The naming follow the one choosed by subscriptions-transport-ws.

This is required to properly close ws connection opened for example with graphiql-workspace (1 per tab)